### PR TITLE
Add shortcuts for singleplayer and multiplayer setups

### DIFF
--- a/Builds/Opencraft Client.bat
+++ b/Builds/Opencraft Client.bat
@@ -1,0 +1,1 @@
+Opencraft.exe -deploymentID 1 -remoteConfig -deploymentURL 127.0.0.1

--- a/Builds/Opencraft Local.bat
+++ b/Builds/Opencraft Local.bat
@@ -1,0 +1,1 @@
+Opencraft.exe -deploymentID 0 -deploymentJson deployment.json

--- a/Builds/Opencraft Server.bat
+++ b/Builds/Opencraft Server.bat
@@ -1,0 +1,1 @@
+Opencraft.exe -deploymentID 0 -deploymentJson deploymentMul.json

--- a/Builds/deployment.json
+++ b/Builds/deployment.json
@@ -1,0 +1,22 @@
+{
+"nodes":[
+	{
+		"nodeID":0,
+		"worldConfigs":[
+			{
+			"worldName": "GameServer",
+			"worldType":"Server",
+			"initializationMode":"Connect",
+			"serverNodeID":0,
+			},
+			{
+			"worldName": "GameClient",
+			"worldType":"Client",
+			"initializationMode":"Connect",
+			"serverNodeID":0
+			}
+		]
+	}
+], 
+"experimentActions":[]
+}

--- a/Builds/deployment.json
+++ b/Builds/deployment.json
@@ -1,22 +1,22 @@
 {
-"nodes":[
-	{
-		"nodeID":0,
-		"worldConfigs":[
-			{
-			"worldName": "GameServer",
-			"worldType":"Server",
-			"initializationMode":"Connect",
-			"serverNodeID":0,
-			},
-			{
-			"worldName": "GameClient",
-			"worldType":"Client",
-			"initializationMode":"Connect",
-			"serverNodeID":0
-			}
-		]
-	}
-], 
-"experimentActions":[]
+	"nodes": [
+		{
+			"nodeID": 0,
+			"worldConfigs": [
+				{
+					"worldName": "GameServer",
+					"worldType": "Server",
+					"initializationMode": "Connect",
+					"serverNodeID": 0,
+				},
+				{
+					"worldName": "GameClient",
+					"worldType": "Client",
+					"initializationMode": "Connect",
+					"serverNodeID": 0
+				}
+			]
+		}
+	],
+	"experimentActions": []
 }

--- a/Builds/deploymentMul.json
+++ b/Builds/deploymentMul.json
@@ -1,29 +1,27 @@
 {
- "nodes":[
-     {
-         "nodeID":0,
-         "worldConfigs":[
-             {
-             "worldName": "GameServer",
-             "worldType":"Server",
-             "initializationMode":"Connect",
-             "serverNodeID":0,
-             }
-         ]
-     },
-     {
-         "nodeID":1,
-         "worldConfigs":[
-             {
-             "worldName": "GameClient",
-             "worldType":"Client",
-             "initializationMode":"Connect",
-             "serverNodeID":0
-             }
-         ]
-     }
- ], 
- "experimentActions":[
-     
- ]
- }
+    "nodes": [
+        {
+            "nodeID": 0,
+            "worldConfigs": [
+                {
+                    "worldName": "GameServer",
+                    "worldType": "Server",
+                    "initializationMode": "Connect",
+                    "serverNodeID": 0,
+                }
+            ]
+        },
+        {
+            "nodeID": 1,
+            "worldConfigs": [
+                {
+                    "worldName": "GameClient",
+                    "worldType": "Client",
+                    "initializationMode": "Connect",
+                    "serverNodeID": 0
+                }
+            ]
+        }
+    ],
+    "experimentActions": []
+}

--- a/Builds/deploymentMul.json
+++ b/Builds/deploymentMul.json
@@ -1,0 +1,29 @@
+{
+ "nodes":[
+     {
+         "nodeID":0,
+         "worldConfigs":[
+             {
+             "worldName": "GameServer",
+             "worldType":"Server",
+             "initializationMode":"Connect",
+             "serverNodeID":0,
+             }
+         ]
+     },
+     {
+         "nodeID":1,
+         "worldConfigs":[
+             {
+             "worldName": "GameClient",
+             "worldType":"Client",
+             "initializationMode":"Connect",
+             "serverNodeID":0
+             }
+         ]
+     }
+ ], 
+ "experimentActions":[
+     
+ ]
+ }


### PR DESCRIPTION
Add `.bat` files in the `Builds` directory that allow developers to quickly start a singleplayer or multiplayer (server+client) instance of the game.